### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ and agree upon. We provide a single node JSON file at cmd/getrue/genesis_single.
       }
   },
   "alloc":{
-    "0x7c357530174275dd30e46319b89f71186256e4f7" : { "balance" : 90000000000000000000000},
-    "0x4cf807958b9f6d9fd9331397d7a89a079ef43288" : { "balance" : 90000000000000000000000}
+    "0x7c357530174275dd30e46319b89f71186256e4f7" : { "balance" : "90000000000000000000000"},
+    "0x4cf807958b9f6d9fd9331397d7a89a079ef43288" : { "balance" : "90000000000000000000000"}
   },
   "committee":[
     {


### PR DESCRIPTION
In the section `Defining the private genesis state`, the `genesis.json` is not correct. We need to change it from `XXX` to `"XXX"` like this:
```code
  "alloc":{
    "0x7c357530174275dd30e46319b89f71186256e4f7" : { "balance" : "90000000000000000000000"},
    "0x4cf807958b9f6d9fd9331397d7a89a079ef43288" : { "balance" : "90000000000000000000000"}
  },
```

Otherwise,  we will encounter error like this:
```code
root@7bfb2b17e40a:/opt/truechain# ./getrue init ./genesis.json
INFO [05-08|07:02:44.490] Enabling metrics collection
Fatal: invalid genesis file: json: cannot unmarshal number into Go struct field Genesis.alloc of type *math.HexOrDecimal256
```